### PR TITLE
Join leave.levelup client

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -68,7 +68,7 @@ export const Register = () => {
                     <input ref={verifyPassword} type="password" name="verifyPassword" className="form-control" placeholder="Verify password" required />
                 </fieldset>
                 <fieldset>
-                    <label htmlFor="verifyPassword"> Verify Password </label>
+                    <label htmlFor="verifyPassword"> Bio </label>
                     <textarea ref={bio} name="bio" className="form-control" placeholder="Let other gamers know a little bit about you..." />
                 </fieldset>
                 <fieldset style={{

--- a/src/components/event/EventList.js
+++ b/src/components/event/EventList.js
@@ -16,16 +16,16 @@ export const EventList = (props) => {
         // whenever confirmed by clicking OK/Cancel window.confirm() returns boolean 
         let text = 'Are you sure you want to delete'
         window.confirm(text)
-            ? deleteEvent(event.id).then(() => navigate("/events"))
+            ? deleteEvent(event.id).then(() => getEvents().then(data => setEvents(data)))
             : <></>
     }
 
     const handleUnJoin = (eventId) => {
-        leaveEvent(eventId).then(data => { })
+        leaveEvent(eventId).then(() => getEvents().then(data => setEvents(data)))
     }
 
     const handleJoin = (eventId) => {
-        joinEvent(eventId).then(data => setEvents(data))
+        joinEvent(eventId).then(() => getEvents().then(data => setEvents(data)))
     }
 
 

--- a/src/components/event/EventList.js
+++ b/src/components/event/EventList.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { deleteEvent, getEvents } from "../../managers/EventManager.js"
+import { deleteEvent, getEvents, joinEvent, leaveEvent } from "../../managers/EventManager.js"
 import "./Event.css"
 
 export const EventList = (props) => {
@@ -19,6 +19,15 @@ export const EventList = (props) => {
             ? deleteEvent(event.id).then(() => navigate("/events"))
             : <></>
     }
+
+    const handleUnJoin = (eventId) => {
+        leaveEvent(eventId).then(data => { })
+    }
+
+    const handleJoin = (eventId) => {
+        joinEvent(eventId).then(data => setEvents(data))
+    }
+
 
     return (<>
         <header className="title is-3 p-2 has-text-centered" id="event__list-title">Events</header>
@@ -50,6 +59,13 @@ export const EventList = (props) => {
                                 </div>
                                 <div className="mt-1">
                                     <button className="btn__events button is-small is-danger" onClick={(evt) => { confirmDelete(evt, event) }}>Delete</button>
+                                </div>
+                                <div className="mt-6">
+                                    {
+                                        event.joined
+                                            ? <button className="button is-warning is-normal is-rounded p-3" onClick={() => { handleUnJoin(event.id) }}>Leave</button>
+                                            : <button className="button is-primary is-normal is-rounded" onClick={() => { handleJoin(event.id) }}>Join</button>
+                                    }
                                 </div>
                             </div>
                         </div>

--- a/src/components/event/EventList.js
+++ b/src/components/event/EventList.js
@@ -16,11 +16,13 @@ export const EventList = (props) => {
         // whenever confirmed by clicking OK/Cancel window.confirm() returns boolean 
         let text = 'Are you sure you want to delete'
         window.confirm(text)
-            ? deleteEvent(event.id).then(() => getEvents().then(data => setEvents(data)))
+            ? deleteEvent(event.id)
+                .then(() => getEvents()
+                    .then(data => setEvents(data)))
             : <></>
     }
 
-    const handleUnJoin = (eventId) => {
+    const handleLeave = (eventId) => {
         leaveEvent(eventId).then(() => getEvents().then(data => setEvents(data)))
     }
 
@@ -63,7 +65,7 @@ export const EventList = (props) => {
                                 <div className="mt-6">
                                     {
                                         event.joined
-                                            ? <button className="button is-warning is-normal is-rounded p-3" onClick={() => { handleUnJoin(event.id) }}>Leave</button>
+                                            ? <button className="button is-warning is-normal is-rounded p-3" onClick={() => { handleLeave(event.id) }}>Leave</button>
                                             : <button className="button is-primary is-normal is-rounded" onClick={() => { handleJoin(event.id) }}>Join</button>
                                     }
                                 </div>

--- a/src/components/event/EventList.js
+++ b/src/components/event/EventList.js
@@ -26,14 +26,14 @@ export const EventList = (props) => {
             onClick={() => {
                 navigate({ pathname: "/events/new" })
             }}
-        ><span className="has-text-weight-semibold is-size-5">Register New Event</span></button>
+        ><span className="has-text-weight-semibold is-size-5">Schedule New Event</span></button>
         <article className="events">
             {
                 events.map(event => {
                     return <React.Fragment key={`game--${event.id}`}>
                         <div className="columns box columns" id="event__list">
                             <section className="event column">
-
+                                <div><h2>Welcome: Event Details Below</h2></div>
                                 <div className="game__title has-text-left">Organizer: {event.organizer.full_name}</div>
                                 <div className="game__title has-text-left">Game: {event.game.title}</div>
                                 <div className="game__players has-text-left">Description: {event.description}</div>

--- a/src/components/game/GameList.js
+++ b/src/components/game/GameList.js
@@ -16,9 +16,7 @@ export const GameList = (props) => {
         // whenever confirmed by clicking OK/Cancel window.confirm() returns boolean 
         let text = 'Are you sure you want to delete'
         window.confirm(text)
-            ? deleteGame(game.id)
-                .then(getGames()
-                    .then(data => setGames(data)))
+            ? deleteGame(game.id).then(() => getGames().then(data => setGames(data)))
             : <></>
     }
 

--- a/src/index.css
+++ b/src/index.css
@@ -92,7 +92,7 @@ code {
 
 /* Icon separator */
 .btn-sep {
-	padding: 25px 30px 25px 30px;
+	padding: 20px 20px 20px 70px;
 }
 
 .btn-sep:before {

--- a/src/managers/EventManager.js
+++ b/src/managers/EventManager.js
@@ -50,8 +50,8 @@ export const deleteEvent = (eventId) => {
     })
 }
 
-//~ JOIN EVENT MANAGERS
-// DELETE user (unJoin) from event
+//~ JOIN/LEAVE EVENT MANAGERS
+// DELETE user (Leave) from event
 export const leaveEvent = (eventId) => {
     // TODO: Write the DELETE fetch request to leave an event
     return fetch(`http://localhost:8000/events/${eventId}/leave`, {

--- a/src/managers/EventManager.js
+++ b/src/managers/EventManager.js
@@ -60,7 +60,6 @@ export const leaveEvent = (eventId) => {
     })
 }
 
-
 // POST user (Join) on an event
 export const joinEvent = (eventId) => {
     // TODO: Write the POST fetch request to join and event

--- a/src/managers/EventManager.js
+++ b/src/managers/EventManager.js
@@ -49,3 +49,23 @@ export const deleteEvent = (eventId) => {
         headers: { "Authorization": `Token ${localStorage.getItem("lu_token")}` },
     })
 }
+
+//~ JOIN EVENT MANAGERS
+// DELETE user (unJoin) from event
+export const leaveEvent = (eventId) => {
+    // TODO: Write the DELETE fetch request to leave an event
+    return fetch(`http://localhost:8000/events/${eventId}/leave`, {
+        method: "DELETE",
+        headers: { "Authorization": `Token ${localStorage.getItem("lu_token")}` },
+    })
+}
+
+
+// POST user (Join) on an event
+export const joinEvent = (eventId) => {
+    // TODO: Write the POST fetch request to join and event
+    return fetch(`http://localhost:8000/events/${eventId}/signup`, {
+        method: "POST",
+        headers: { "Authorization": `Token ${localStorage.getItem("lu_token")}` },
+    })
+}


### PR DESCRIPTION
## Join/Leave an Event

- [x]  Created `Join` and `Leave` Fetch calls in `EventManager.js`

```
//~ JOIN/LEAVE EVENT MANAGERS
// DELETE user (Leave) from event
export const leaveEvent = (eventId) => {
    // TODO: Write the DELETE fetch request to leave an event
    return fetch(`http://localhost:8000/events/${eventId}/leave`, {
        method: "DELETE",
        headers: { "Authorization": `Token ${localStorage.getItem("lu_token")}` },
    })
}

// POST user (Join) on an event
export const joinEvent = (eventId) => {
    // TODO: Write the POST fetch request to join and event
    return fetch(`http://localhost:8000/events/${eventId}/signup`, {
        method: "POST",
        headers: { "Authorization": `Token ${localStorage.getItem("lu_token")}` },
    })
}
```
- [x] Update `EvenList.js` with buttons to handle Leave/Join `onClick`

```
{
    event.joined
          ? <button className="button is-warning is-normal is-rounded p-3" onClick={() => { handleLeave(event.id) }}>Leave</button>
          : <button className="button is-primary is-normal is-rounded" onClick={() => { handleJoin(event.id) }}>Join</button>
}
```
- [x] added handleLeave and handleJoin functions to facilitate action on click

```
    const handleLeave = (eventId) => {
        leaveEvent(eventId).then(() => getEvents().then(data => setEvents(data)))
    }

    const handleJoin = (eventId) => {
        joinEvent(eventId).then(() => getEvents().then(data => setEvents(data)))
    }
```
- [x] update `deleteEvent`, `handleLeave`, and `handleJoin` with proper state reset...

```
            .then(() => getEvents()
            .then(data => setEvents(data)))
```
